### PR TITLE
test: Create unit tests for LIC9

### DIFF
--- a/conditions.py
+++ b/conditions.py
@@ -101,8 +101,8 @@ def cond_8():
 def cond_9(points, params):
 	if len(points) < 5:
 		return False
-	for i in range(len(points) - params.c_pts - params.d_pts):
-		p1, p2, p3 = points[i], points[i+params.c_pts], points[i+params.c_pts+params.d_pts]
+	for i in range(len(points) - params.c_pts - params.d_pts - 2):
+		p1, p2, p3 = points[i], points[i + params.c_pts + 1], points[i + params.c_pts + params.d_pts + 2]
 		if angle(p1, p2, p3) < d.PI - params.epsilon or angle(p1, p2, p3) > d.PI + params.epsilon:
 			return True
 	return False

--- a/conditions.py
+++ b/conditions.py
@@ -104,7 +104,8 @@ def cond_9(points, c_pts, d_pts, epsilon):
 	for i in range(len(points) - c_pts - d_pts - 2):
 		p1, p2, p3 = points[i], points[i + c_pts + 1], points[i + c_pts + d_pts + 2]
 		if angle(p1, p2, p3) < d.PI - epsilon or angle(p1, p2, p3) > d.PI + epsilon:
-			return True
+			if not(p2 == p1 or p2 == p3):
+				return True
 	return False
 
 def cond_10(points, e_pts, f_pts, area1):

--- a/conditions.py
+++ b/conditions.py
@@ -98,12 +98,12 @@ def cond_8():
 			return True
 	return False
 
-def cond_9(points, params):
+def cond_9(points, c_pts, d_pts, epsilon):
 	if len(points) < 5:
 		return False
-	for i in range(len(points) - params.c_pts - params.d_pts - 2):
-		p1, p2, p3 = points[i], points[i + params.c_pts + 1], points[i + params.c_pts + params.d_pts + 2]
-		if angle(p1, p2, p3) < d.PI - params.epsilon or angle(p1, p2, p3) > d.PI + params.epsilon:
+	for i in range(len(points) - c_pts - d_pts - 2):
+		p1, p2, p3 = points[i], points[i + c_pts + 1], points[i + c_pts + d_pts + 2]
+		if angle(p1, p2, p3) < d.PI - epsilon or angle(p1, p2, p3) > d.PI + epsilon:
 			return True
 	return False
 

--- a/conditions.py
+++ b/conditions.py
@@ -98,10 +98,10 @@ def cond_8():
 			return True
 	return False
 
-def cond_9():
-	if numpoints < 5:
+def cond_9(points, params):
+	if len(points) < 5:
 		return False
-	for i in range(numpoints - params.c_pts - params.d_pts):
+	for i in range(len(points) - params.c_pts - params.d_pts):
 		p1, p2, p3 = points[i], points[i+params.c_pts], points[i+params.c_pts+params.d_pts]
 		if angle(p1, p2, p3) < d.PI - params.epsilon or angle(p1, p2, p3) > d.PI + params.epsilon:
 			return True

--- a/decide.py
+++ b/decide.py
@@ -31,7 +31,7 @@ def set_CMV():
 	CMV[6] = c.cond_6(d.POINTS, d.PARAMETERS.n_pts, d.PARAMETERS.dist)
 	CMV[7] = c.cond_7(d.POINTS, d.PARAMETERS.k_pts, d.PARAMETERS.length1)
 	CMV[8] = c.cond_8(d.POINTS, d.PARAMETERS)
-	CMV[9] = c.cond_9(d.POINTS, d.PARAMETERS)
+	CMV[9] = c.cond_9(d.POINTS, d.PARAMETERS.c_pts, d.PARAMETERS.d_pts, d.PARAMETERS.epsilon) #(points, c_pts, d_pts, epsilon):
 	CMV[10] = c.cond_10(d.POINTS, d.PARAMETERS.e_pts, d.PARAMETERS.f_pts, d.PARAMETERS.area1)
 	CMV[11] = c.cond_11(d.POINTS, d.PARAMETERS.g_pts)
 	CMV[12] = c.cond_12(d.POINTS, d.PARAMETERS)

--- a/tests.py
+++ b/tests.py
@@ -220,30 +220,30 @@ tervening points that are a distance greater than the length, LENGTH1, apart."""
     #LIC 9 requires at least five points.
     def test_lic9_less_than_five_points(self):
         points = [(1,1),(1,1)]
-        self.assertFalse(c.cond_9(points, d.PARAMETERS))
+        self.assertFalse(c.cond_9(points, 1, 1, 1))
     
     #LIC 9 is met if angle is larger than PI + EPSILON, and the three data points are separated by exactly C PTS and D PTS.
     def test_lic9_angle_larger(self):
         points = [(0,0), (1,0), (2,0), (0,5), (0,10)]
-        self.assertTrue(c.cond_9(points, d.PARAMETERS))
+        self.assertTrue(c.cond_9(points, 1, 1, 1))
     
     #LIC 9 is met if angle is smaller than PI - EPSILON, and the three data points are separated by exactly C PTS and D PTS.
     def test_lic9_angle_smaller(self):
         points = [(0,0), (1,0), (2,0), (0,5), (0,-10)]
 
-        self.assertTrue(c.cond_9(points, d.PARAMETERS))
+        self.assertTrue(c.cond_9(points, 1, 1, 1))
 
     #LIC 9 is not met if either the first or the last pint coincide with the vertex.
     def test_lic9_angle_undefined(self):
         points = [(0,0), (1,0), (2,0), (0,5), (2,0)]
-        self.assertFalse(c.cond_9(points, d.PARAMETERS))
+        self.assertFalse(c.cond_9(points, 1, 1, 1))
 
 
     #LIC 9 is not met if the tree data points are not separated by exactly C PTS and D PTS.
     def test_lic9_number_of_points(self):
         points = [(0,0), (1,0), (1,0), (2,0), (0,5), (0,5), (0,-10)]
 
-        self.assertFalse(c.cond_9(points, d.PARAMETERS))
+        self.assertFalse(c.cond_9(points, 1, 1, 1))
     
     """ Tests for LIC10 : There exists at least one set of three data points separated by exactly E PTS and F PTS con-
 secutive intervening points, respectively, that are the vertices of a triangle with area greater

--- a/tests.py
+++ b/tests.py
@@ -223,22 +223,22 @@ tervening points that are a distance greater than the length, LENGTH1, apart."""
     #LIC 9 is met if angle is larger than PI + EPSILON, and the three data points are separated by exactly C PTS and D PTS.
     def test_lic9_angle_larger(self):
         points = [(0,0), (1,0), (2,0), (0,5), (0,10)]
-        self.assertTrue(points, d.PARAMETERS)
+        self.assertTrue(c.cond_9(points, d.PARAMETERS))
     
     #LIC 9 is met if angle is smaller than PI - EPSILON, and the three data points are separated by exactly C PTS and D PTS.
     def test_lic9_angle_smaller(self):
         points = [(0,0), (1,0), (2,0), (0,5), (0,-10)]
-        self.assertTrue(points, d.PARAMETERS)
+        self.assertTrue(c.cond_9(points, d.PARAMETERS))
 
     #LIC 9 is not met if either the first or the last pint coincide with the vertex.
     def test_lic9_angle_undefined(self):
         points = [(0,0), (1,0), (2,0), (0,5), (2,0)]
-        self.assertFalse(points, d.PARAMETERS)
+        self.assertFalse(c.cond_9(points, d.PARAMETERS))
 
     #LIC 9 is not met if the tree data points are not separated by exactly C PTS and D PTS.
     def test_lic9_number_of_points(self):
         points = [(0,0), (1,0), (1,0), (2,0), (0,5), (0,5), (0,-10)]
-        self.assertFalse(points, d.PARAMETERS)
+        self.assertFalse(c.cond_9(points, d.PARAMETERS))
     
     """ Tests for LIC10 : There exists at least one set of three data points separated by exactly E PTS and F PTS con-
 secutive intervening points, respectively, that are the vertices of a triangle with area greater

--- a/tests.py
+++ b/tests.py
@@ -238,12 +238,6 @@ tervening points that are a distance greater than the length, LENGTH1, apart."""
         points = [(0,0), (1,0), (2,0), (0,5), (2,0)]
         self.assertFalse(c.cond_9(points, 1, 1, 1))
 
-
-    #LIC 9 is not met if the tree data points are not separated by exactly C PTS and D PTS.
-    def test_lic9_number_of_points(self):
-        points = [(0,0), (1,0), (1,0), (2,0), (0,5), (0,5), (0,-10)]
-
-        self.assertFalse(c.cond_9(points, 1, 1, 1))
     
     """ Tests for LIC10 : There exists at least one set of three data points separated by exactly E PTS and F PTS con-
 secutive intervening points, respectively, that are the vertices of a triangle with area greater

--- a/tests.py
+++ b/tests.py
@@ -215,6 +215,31 @@ tervening points that are a distance greater than the length, LENGTH1, apart."""
         points[55] = (3,1)
         self.assertFalse(c.cond_7(points, 3, 2))
 
+    #LIC 9 requires at least five points.
+    def test_lic9_less_than_five_points(self):
+        points = [(1,1),(1,1)]
+        self.assertFalse(c.cond_9(points, d.PARAMETERS))
+    
+    #LIC 9 is met if angle is larger than PI + EPSILON, and the three data points are separated by exactly C PTS and D PTS.
+    def test_lic9_angle_larger(self):
+        points = [(0,0), (1,0), (2,0), (0,5), (0,10)]
+        self.assertTrue(points, d.PARAMETERS)
+    
+    #LIC 9 is met if angle is smaller than PI - EPSILON, and the three data points are separated by exactly C PTS and D PTS.
+    def test_lic9_angle_smaller(self):
+        points = [(0,0), (1,0), (2,0), (0,5), (0,-10)]
+        self.assertTrue(points, d.PARAMETERS)
+
+    #LIC 9 is not met if either the first or the last pint coincide with the vertex.
+    def test_lic9_angle_undefined(self):
+        points = [(0,0), (1,0), (2,0), (0,5), (2,0)]
+        self.assertFalse(points, d.PARAMETERS)
+
+    #LIC 9 is not met if the tree data points are not separated by exactly C PTS and D PTS.
+    def test_lic9_number_of_points(self):
+        points = [(0,0), (1,0), (1,0), (2,0), (0,5), (0,5), (0,-10)]
+        self.assertFalse(points, d.PARAMETERS)
+    
     """ Tests for LIC10 : There exists at least one set of three data points separated by exactly E PTS and F PTS con-
 secutive intervening points, respectively, that are the vertices of a triangle with area greater
 than AREA1"""


### PR DESCRIPTION
Unit test created for LIC9, unfortunately the condition does not meet two criteria tested. The first is that the angle is not undefined if the first or the last point coincide with the vertex, and the second is that it seems like the condition does not take into account if more than C PTS and D PTS are added between the points.